### PR TITLE
Finish restyling tables/buttons for admin queue

### DIFF
--- a/scripts/templates/master.mak
+++ b/scripts/templates/master.mak
@@ -88,7 +88,7 @@ else:
         color: white;
         text-decoration: none;
       }
-      a.btn.edit-btn, span.edit-btn-disabled {
+      a.btn.sm-btn, span.edit-btn-disabled {
         display: inline-block;
         padding: 0.25em 0.5em;
         border-radius: 0.4em;
@@ -153,7 +153,7 @@ else:
       %endif
     </li>
     %if auth.on_scripts_team():
-      <li><a href="${tg.url('/queue')}">Admin Queue</a></li>
+      <li><a href="${tg.url('/queue')}"><span class="fa fa-th-list"></span> Admin Queue</a></li>
     %endif    
     <li><a href="http://scripts.mit.edu/"><span class="fa fa-home"></span> scripts.mit.edu home</a></li>
 </ul>

--- a/scriptspony/templates/index.mak
+++ b/scriptspony/templates/index.mak
@@ -22,7 +22,7 @@ from scripts import auth
 	    <small>/mit/${locker}/web_scripts/</small>${path}
 	  </td>
           %if host not in (locker+'.scripts.mit.edu',):
-            <td class="nbr"><a href="${tg.url('/edit/'+locker+'/'+host)}" class="btn edit-btn" aria-label="Edit"><span class="fa fa-pencil" aria-hidden="true"></span></a></td>
+            <td class="nbr"><a href="${tg.url('/edit/'+locker+'/'+host)}" class="btn sm-btn" aria-label="Edit"><span class="fa fa-pencil" aria-hidden="true"></span></a></td>
           %else:
             <td><span class="edit-btn-disabled"><span class="fa fa-ban"></span></span></td>
           %endif

--- a/scriptspony/templates/queue.mak
+++ b/scriptspony/templates/queue.mak
@@ -1,7 +1,7 @@
 <%inherit file="scripts.templates.master"/>
 
 <table border="1">
-  <tr><th>#</th><th>RT ID</th><th>User</th><th>Locker</th><th>Hostname</th><th>State</th></tr>
+  <tr><th>#</th><th>RT ID</th><th>User</th><th>Locker</th><th>Hostname</th><th>State</th><th colspan="2">Actions</th></tr>
   %for t in tickets:
     <tr>
       <td><a href="${tg.url('/ticket/%s'%t.id)}">${t.id}</a></td>
@@ -12,8 +12,10 @@
       %endif
       <td>${t.requestor}</td><td>${t.locker}</td><td>${t.hostname}</td><td>${t.state}</td>
       %if t.state == 'open':
-        <td><a href="${tg.url('/approve/%s'%t.id)}">Approve</a></td>
-        <td><a href="${tg.url('/reject/%s'%t.id)}">Reject</a></td>
+        <td><a href="${tg.url('/approve/%s'%t.id)}" class="btn sm-btn" aria-label="Approve" title="Approve"><span class="fa fa-check" aria-hidden="true"></span></a></td>
+        <td><a href="${tg.url('/reject/%s'%t.id)}" class="btn sm-btn" aria-label="Reject" title="Reject"><span class="fa fa-ban" aria-hidden="true"></span></a></td>
+      %else:
+        <td></td><td></td>
       %endif
     </tr>
 %if t.state == 'open':
@@ -33,6 +35,6 @@
     %for s in all:
       <label><input type="checkbox" name="${s}" value="1"${' checked' if s in included else ''} /> ${s}</label>
     %endfor
-    <input type="submit" value="Filter" />
+    <button class="btn"><span class="fa fa-filter"></span> Filter</button>
   </form>
 %endif


### PR DESCRIPTION
- Add FontAwesome icons to admin queue menu item and Filter button.
- Style "Approve" and "Reject" like small buttons. Rename edit-btn to
  sm-btn now that we have more small-button-styled links.
- Add table cells when buttons are not there for consistent table look.

Tested a little, but not thoroughly as I couldn't get all the different kinds of entries to show up in my table through the UI and was too lazy to manually do something in the database.
<img width="787" alt="screen shot 2016-10-24 at 1 34 35 am" src="https://cloud.githubusercontent.com/assets/3482833/19634557/16037e7a-998a-11e6-98e3-4238f5393ad3.png">
